### PR TITLE
Efficient ignore fields

### DIFF
--- a/fw1-loggrabber.c
+++ b/fw1-loggrabber.c
@@ -1143,6 +1143,7 @@ read_fw1_logfile_dict (OpsecSession * psession, int dict_id, LEA_VT val_type,
                        int n_d_entries)
 {
   lea_value_t d_value;
+  int x;
 
   if (cfgvalues.debug_mode >= 2)
     {

--- a/fw1-loggrabber.c
+++ b/fw1-loggrabber.c
@@ -347,6 +347,11 @@ main (int argc, char *argv[])
       while (field != NULL)
         {
           ignore_fields_count++;
+          if (ignore_fields_count >= NUMBER_FIELDS)
+            {
+              break;
+            }
+
           ignore_fields_array =
             (char **) realloc (ignore_fields_array, ignore_fields_count * sizeof (char *));
           if (ignore_fields_array == NULL)
@@ -969,7 +974,7 @@ read_fw1_logfile_record (OpsecSession * pSession, lea_record * pRec,
        */
       for (x = 0; x < ignore_fields_count; x++)
         {
-          if (string_icmp(ignore_fields_array[x], szAttrib)==0)
+          if (ignore_attr_id_array[x] == pRec->fields[i].lea_attr_id)
             {
               ignore = TRUE;
               break;
@@ -1137,6 +1142,8 @@ int
 read_fw1_logfile_dict (OpsecSession * psession, int dict_id, LEA_VT val_type,
                        int n_d_entries)
 {
+  lea_value_t d_value;
+
   if (cfgvalues.debug_mode >= 2)
     {
       fprintf (stderr, "DEBUG: function read_fw1_logfile_dict\n");
@@ -1146,6 +1153,23 @@ read_fw1_logfile_dict (OpsecSession * psession, int dict_id, LEA_VT val_type,
     {
       fprintf (stderr, "DEBUG: LEA logfile dict handler was invoked\n");
     }
+
+  if (ignore_fields_count && dict_id == LEA_ATTRIB_ID)
+    {
+      for (x = 0; x < ignore_fields_count; x++)
+        {
+          if ((lea_reverse_dictionary_lookup(psession, LEA_ATTRIB_ID, ignore_fields_array[x],
+                                             &d_value)) != LEA_NOT_FOUND)
+            {
+              ignore_attr_id_array[x] = d_value.i_value;
+            }
+          else
+            {
+              ignore_attr_id_array[x] = -1;
+            }
+        }
+    }
+
   return OPSEC_SESSION_OK;
 }
 

--- a/fw1-loggrabber.c
+++ b/fw1-loggrabber.c
@@ -1159,13 +1159,25 @@ read_fw1_logfile_dict (OpsecSession * psession, int dict_id, LEA_VT val_type,
     {
       for (x = 0; x < ignore_fields_count; x++)
         {
+          if (cfgvalues.debug_mode)
+            {
+              fprintf (stderr, "DEBUG: Checking attribute id for %s\n", ignore_fields_array[x]);
+            }
           if ((lea_reverse_dictionary_lookup(psession, LEA_ATTRIB_ID, ignore_fields_array[x],
                                              &d_value)) != LEA_NOT_FOUND)
             {
+              if (cfgvalues.debug_mode)
+                {
+                  fprintf (stderr, "DEBUG: Got attribute id %i\n", d_value.i_value);
+                }
               ignore_attr_id_array[x] = d_value.i_value;
             }
           else
             {
+            if (cfgvalues.debug_mode)
+              {
+                fprintf (stderr, "DEBUG: No attribute id found\n");
+              }
               ignore_attr_id_array[x] = -1;
             }
         }

--- a/fw1-loggrabber.c
+++ b/fw1-loggrabber.c
@@ -1174,10 +1174,10 @@ read_fw1_logfile_dict (OpsecSession * psession, int dict_id, LEA_VT val_type,
             }
           else
             {
-            if (cfgvalues.debug_mode)
-              {
-                fprintf (stderr, "DEBUG: No attribute id found\n");
-              }
+              if (cfgvalues.debug_mode)
+                {
+                  fprintf (stderr, "DEBUG: No attribute id found\n");
+                }
               ignore_attr_id_array[x] = -1;
             }
         }

--- a/fw1-loggrabber.conf
+++ b/fw1-loggrabber.conf
@@ -22,6 +22,15 @@ RESOLVE_MODE="no"
 # RECORD_SEPARATOR=<char>
 RECORD_SEPARATOR="|"
 
+# DATEFORMAT=<cp|unix|std>
+#   cp   = " 3Feb2004 14:15:16"
+#   unix = "1051655431"
+#   std  = "2004-02-03 14:15:16"
+DATEFORMAT="std"
+
+# IGNORE_FIELDS=<field1;field2;...>
+#IGNORE_FIELDS="uuid;__policy_id_tag"
+
 # LOGGING_CONFIGURATION=<screen|file|syslog>
 LOGGING_CONFIGURATION=screen
 

--- a/fw1-loggrabber.h
+++ b/fw1-loggrabber.h
@@ -332,6 +332,7 @@ int create_tables = FALSE;
 char *ignore_fields = NULL;
 int ignore_fields_count = 0;
 char **ignore_fields_array = NULL;
+int ignore_attr_id_array[NUMBER_FIELDS] = { 0 };
 
 OpsecSession* pSession = NULL;
 OpsecEnv*     pEnv     = NULL;


### PR DESCRIPTION
I switched the logic for ignoring fields to use a much more efficient array of integers to test against the lea_attr_id of a field instead of doing a string compare of the field name for each record. The array of integers is built when the dictionary of attribute IDs is downloaded to the client when the LEA session begins, and each time the remote log file is switched. 

I also updated the sample configuration file to include the DATEFORMAT and IGNORE_FIELDS example fields.