### PR TITLE
Online mode starts reading logs from the end of file and collect new …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CC = $(GCC_PREFIX)/bin/$(CC_CMD)
 LD = $(GCC_PREFIX)/bin/$(LD_CMD)
 
 EXE_NAME = fw1-loggrabber
-OBJ_FILES = thread.o queue.o fw1-loggrabber.o
+OBJ_FILES = thread.o queue.o fw1-cursor.o fw1-loggrabber.o
 
 CFLAGS += -m32 -g -Wall -fpic -DLINUX -DUNIXOS=1 -DDEBUG
 SYSTEM_LIBS = -lpthread -lresolv -ldl -lnsl -lelf -lstdc++ -lz

--- a/fw1-cursor.c
+++ b/fw1-cursor.c
@@ -1,0 +1,79 @@
+#include "fw1-cursor.h"
+
+int read_fw1_cursorfile (const char *LogfileName) {
+  FILE *fd;
+  char line[POSITION_MAX_SIZE];
+
+  char *current_cursor = get_fw1_cursorname (LogfileName);
+  fd = fopen (current_cursor,"r");
+
+  if (fd == NULL)
+   {
+      fprintf (stderr, "Error while opening the file %s in read mode.\n", current_cursor);
+      fprintf (stderr, "Maybe, it doesn't exist yet.\n");
+      free(current_cursor);
+      return 0;
+   }
+   free(current_cursor);
+
+   fgets (line, POSITION_MAX_SIZE, fd);
+   fclose (fd);
+
+   return atoi (line);
+}
+
+void write_fw1_cursorfile (const char *LogfileName, const char *message, const char separator) {
+  FILE *fd;
+
+  char *current_cursor = get_fw1_cursorname (LogfileName);
+  char position[POSITION_MAX_SIZE];
+  int i, j = 0;
+
+  fd = fopen (current_cursor,"r+");
+
+  if (fd == NULL)
+   {
+      fprintf (stderr, "Error while opening the file %s in r+ mode.\n", current_cursor);
+      fprintf (stderr, "Maybe, it doesn't exist yet. Trying to open it in w mode.\n");
+
+      fd = fopen (current_cursor,"w");
+      if (fd == NULL)
+      {
+          fprintf (stderr, "Error while opening the file %s in w mode also.\n", current_cursor);
+          free(current_cursor);
+          exit (EXIT_FAILURE);
+      }
+   }
+   free(current_cursor);
+
+   // Extract cuurent position from message
+   for (i=4; i<strlen (message); i++)
+   {
+     if ((char)message[i] != separator)
+     {
+       position[j] = message[i];
+       j++;
+     }
+     else
+     {
+       break;
+     }
+   }
+
+   fprintf (fd, "%d", atoi (position)+1);
+   fclose (fd);
+}
+
+char* get_fw1_cursorname(const char *LogfileName) {
+  char *cursor_name =
+    (char *) malloc (strlen (LogfileName) + 7);
+  if (cursor_name == NULL)
+    {
+      fprintf (stderr, "ERROR: Out of memory\n");
+      exit(EXIT_FAILURE);
+    }
+  strcpy (cursor_name, LogfileName);
+  strcat (cursor_name, ".cursor");
+
+  return cursor_name;
+}

--- a/fw1-cursor.h
+++ b/fw1-cursor.h
@@ -1,0 +1,14 @@
+#ifndef FW1CURSOR_H
+#define FW1CURSOR_H
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define POSITION_MAX_SIZE 20
+
+int   read_fw1_cursorfile(const char *LogfileName); // Return next log position from cursor file
+void  write_fw1_cursorfile(const char *LogfileName, const char *message, const char separator); // Deduce next log position from current message
+char* get_fw1_cursorname(const char *LogfileName); // Give cursor name associated with log file
+
+#endif

--- a/fw1-cursor.h
+++ b/fw1-cursor.h
@@ -5,10 +5,17 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define POSITION_MAX_SIZE 20
+#define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
+#define POSITION_MAX_SIZE 32
 
-int   read_fw1_cursorfile(const char *LogfileName); // Return next log position from cursor file
-void  write_fw1_cursorfile(const char *LogfileName, const char *message, const char separator); // Deduce next log position from current message
-char* get_fw1_cursorname(const char *LogfileName); // Give cursor name associated with log file
+FILE *cursorstream;
+char cursorline[POSITION_MAX_SIZE + 1];
+
+int read_fw1_cursorfile (); // Return next log position from cursor file
+int write_fw1_cursorfile (const char *message, const char separator); // Deduce next log position from current message
+char* get_fw1_cursorname (const char *LogfileName); // Give cursor name associated with log file
+void open_fw1_cursorfile (const char *LogfileName); // Initialize cursorstream file handler
+void close_fw1_cursorfile (); // Close cursorstream file handler
 
 #endif

--- a/fw1-loggrabber.h
+++ b/fw1-loggrabber.h
@@ -57,11 +57,12 @@
  */
 #include "queue.h"
 #include "thread.h"
+#include "fw1-cursor.h"
 
 /*
  * Constant definitions
  */
-#define VERSION             "2.1"
+#define VERSION             "2.2"
 
 #define TRUE                1
 #define FALSE               0
@@ -79,6 +80,10 @@
 #define INITIAL_CAPACITY    1024
 #define CAPACITY_INCREMENT  4096
 
+#define OFFLINE             0
+#define ONLINE              1
+#define ONLINE_RESUME       2
+
 /*
  * Type definitions
  */
@@ -92,7 +97,7 @@ stringlist;
 typedef struct configvalues
 {
   int debug_mode;
-  int online_mode;
+  int mode;
   int resolve_mode;
   int fw1_2000;
   int audit_mode;
@@ -303,7 +308,7 @@ int fileExist (const char *fileName);
 
 // Worker thread function
 ThreadFuncReturnType leaRecordProcessor( void *data );
-                                                                                                                         
+
 /*
  * pointers to functions
  */
@@ -321,7 +326,7 @@ void (*close_log) ();
  */
 int debug_mode = -1;
 int show_files = -1;
-int online_mode = -1;
+int mode = -1;
 int resolve_mode = -1;
 char *LogfileName = NULL;
 int fw1_2000 = -1;
@@ -376,7 +381,7 @@ char **field_values[NUMBER_FIELDS];
 
 configvalues cfgvalues = {
   0,                            // debug_mode
-  FALSE,                        // online_mode
+  0,                            // mode
   TRUE,                         // resolve_mode
   FALSE,                        // fw1_2000
   FALSE,                        // audit_mode
@@ -419,4 +424,3 @@ int established = FALSE;
 
 int initialCapacity = 1024;
 int capacityIncrement = 4096;
-

--- a/fw1-loggrabber.h
+++ b/fw1-loggrabber.h
@@ -35,6 +35,7 @@
 #include <stdlib.h>
 #include <ctype.h>
 #include <time.h>
+#include <signal.h>
 
 #define  SLEEP(sec) sleep(sec)
 #include <netinet/in.h>
@@ -320,6 +321,9 @@ void (*submit_log) (char *message);
 
 //pointer to function close log pipe
 void (*close_log) ();
+
+//handle signal termination properly 
+void signal_handler(int signal);
 
 /*
  * Global definitions


### PR DESCRIPTION
Online mode starts reading logs from the end of file and collect new logs until the process is stopped.
Offline mode starts reading logs from the start to the end of file and stops.

The new online-resume mode resumes from where it was stopped.
When a log is "submitted" (recorded to file, displayed to screen or send to syslog),
 a cursor file with the next position is updated.
The cursor file is named <firewall_log_file>.cursor.

Mode should be specified in configuration file (not ONLINE_MODE anymore) :

- MODE=OFFLINE
- MODE=ONLINE
- MODE=ONLINE-RESUME

Or in command-line:

- --offline
- --online
- --online-resume