### PR TITLE
Fix malloc off-by-one seg fault due to not accounting for the null terminator

### DIFF
--- a/fw1-cursor.c
+++ b/fw1-cursor.c
@@ -1,5 +1,7 @@
 #include "fw1-cursor.h"
 
+#define CURSOR_FILE_EXT ".cursor"
+
 int read_fw1_cursorfile () {
    rewind (cursorstream);
    fgets (cursorline, (POSITION_MAX_SIZE + 1), cursorstream);
@@ -35,14 +37,14 @@ int write_fw1_cursorfile (const char *message, const char separator) {
 
 char* get_fw1_cursorname(const char *LogfileName) {
   char *cursorname =
-    (char *) malloc (strlen (LogfileName) + 7);
+    (char *) malloc (sizeof(char) * (strlen (LogfileName) + strlen (CURSOR_FILE_EXT) + 1));
   if (cursorname == NULL)
     {
       fprintf (stderr, "ERROR: Out of memory\n");
       exit(EXIT_FAILURE);
     }
   strcpy (cursorname, LogfileName);
-  strcat (cursorname, ".cursor");
+  strcat (cursorname, CURSOR_FILE_EXT);
 
   return cursorname;
 }


### PR DESCRIPTION
We experienced a crash when running the latest master with a simplified decoded backtrace of:

free (cursorname) on line 72 of fw1-cursor.c
open_fw1_cursorfile()
main()

Raw:
*** glibc detected *** /usr/local/bin/fw1-loggrabber: free(): invalid next size (fast): 0x08494768 ***
======= Backtrace: =========
/lib/libc.so.6(+0x70bb1)[0xf742abb1]
/lib/libc.so.6(+0x73611)[0xf742d611]
/usr/local/bin/fw1-loggrabber[0x804e098]
/usr/local/bin/fw1-loggrabber[0x804f432]
/lib/libc.so.6(__libc_start_main+0xe6)[0xf73d0d26]
/usr/local/bin/fw1-loggrabber[0x804d361]

From a review of how cursorname is constructed in get_fw1_cursorname(), it appears that the malloc is one byte too small since ".cursor" is 7 bytes and the NULL terminator is 1 byte. Therefore, it should be:

> char *cursorname =
    (char *) malloc (strlen (LogfileName) + 8); 

instead of:

> char *cursorname =
    (char *) malloc (strlen (LogfileName) + 7);

The fix provided attempts to do the +8 in a more maintainable way by preventing needing to actually count the bytes in ".cursor".