### PR TITLE
Added capability for TCP output

### DIFF
--- a/fw1-loggrabber.c
+++ b/fw1-loggrabber.c
@@ -298,7 +298,6 @@ main (int argc, char *argv[])
       cfgvalues.audit_filter_array = filterarray;
     }
 
-  
   /*
    * free no more used char*
    */
@@ -5151,9 +5150,6 @@ close_screen ()
 
 /*
  * tcplog initializations
- * tcp support was implemented to circumvent 2GB file size limitations
- * and the issues which comes from working around that limitation.
- * using TCP also allows for more efficient log transmission to other platforms.
  */
 void
 open_tcplog()

--- a/fw1-loggrabber.conf
+++ b/fw1-loggrabber.conf
@@ -31,7 +31,7 @@ DATEFORMAT="std"
 # IGNORE_FIELDS=<field1;field2;...>
 #IGNORE_FIELDS="uuid;__policy_id_tag"
 
-# LOGGING_CONFIGURATION=<screen|file|syslog>
+# LOGGING_CONFIGURATION=<screen|file|syslog|tcp>
 LOGGING_CONFIGURATION=screen
 
 # OUTPUT_FILE_PREFIX=<Path and Name of outputfile>
@@ -41,6 +41,18 @@ OUTPUT_FILE_PREFIX="fw1-loggrabber"
 # Please use an external tool (e.g. logrotate) to handle rotation.
 OUTPUT_FILE_ROTATESIZE=0
 # OUTPUT_FILE_ROTATESIZE=<maximum size of outputfile in bytes>
+
+# if LOGGING_CONFIGURATION=tcp then make sure TCP Host and Port are set correctly
+# TCP Host
+OUTPUT_TCPLOG_HOST="127.0.0.1"
+
+# TCP Port
+OUTPUT_TCPLOG_PORT=5500
+
+# TCP reconnect paramaters
+# To disable retries set OUTPUT_TCPLOG_RETRY_INTERVAL=0
+OUTPUT_TCPLOG_RETRY_INTERVAL=6
+OUTPUT_TCPLOG_RETRY_ATTEMPTS=5
 
 # SYSLOG_FACILITY=<USER|LOCAL0|...|LOCAL7>
 SYSLOG_FACILITY="LOCAL1"


### PR DESCRIPTION
This update allows fw1-loggrabber to output CheckPoint logs over TCP.

I implemented this due to the number of issues I was having trying to process the file output, too many edge cases lead to eventual loss of log data, especially when using builtin log rotation, logrotated, or anything else. Even logrotated with pre/post scripts completely stopping and starting the service was becoming an issue. Due to the 32bit process limitation in only being able to write up to 2GB files I've had to resort to restarting services every 10 minutes* to prevent fw1 from crashing at my log ingest rate.  With TCP output I no longer have to deal with any of these issues, also with this option there's much less IO involved which makes the SSD's happy. 

I didn't implement UDP because when payloads are too large the data is sent with multiple packets (as expected). The issue is that so far every SIEM or log platform I've used can't seem to deal with single log events sent over multiple UDP packets and I always see those systems trying to parse truncated log events - so there's no point in using UDP for Checkpoint logs, which I know will always be very large.

The combination of this change and wrapping fw1 with a systemd service file to auto-recover from the occasional unexpected failure turns this into a decently resilient service and I hope others will find this useful.  I'm also working on having the Makefile install a systemd service for fw1 automatically, I'll also create a pull request when I have that working.