### PR TITLE
Make install deploys systemd service file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,15 +61,38 @@ install:
 	@install -v -o root -g root -m 644 -p fw1-loggrabber.conf ${INSTALL_ETC_DIR}/fw1-loggrabber.conf-sample
 	@install -v -o root -g root -m 644 -p lea.conf ${INSTALL_ETC_DIR}/lea.conf-sample
 	@install -v -o root -g root -m 644 -t ${INSTALL_LIB_DIR} ${OPSEC_LIB_DIR}/*.so
+ifeq ($(shell test -d /etc/ld.so.conf.d && echo -n yes),yes)
+	@echo
+	@echo "** ldconfig detected, adding ${INSTALL_LIB_DIR}."
+	@install -v -o root -g root -m 644 -p install/ldconfig/fw1-loggrabber.conf /etc/ld.so.conf.d/fw1-loggrabber.conf
+	rm /etc/ld.so.cache
+	ldconfig
+	@echo
+endif
+ifeq ($(shell test -d /etc/systemd/system && echo -n yes),yes)
+	@install -v -o root -g root -m 644 -p install/systemd/fw1-loggrabber.service /etc/systemd/system/fw1-loggrabber.service
+	systemctl daemon-reload
+	systemctl enable fw1-loggrabber
+	@echo
+	@echo
+	@echo "Installation complete! After configuration files are set you may start the service with the following command;"
+	@echo
+	@echo "  systemctl start fw1-loggrabber"
+else
+	@echo
 	@echo
 	@echo "Installation complete! Please declare the following environment variables in your shell configuration file:"
 	@echo
-	@echo "  LD_LIBRARY_PATH=\$$LD_LIBRARY_PATH:${INSTALL_LIB_DIR}"
-	@echo "  export LD_LIBRARY_PATH"
 	@echo "  LOGGRABBER_CONFIG_PATH=${INSTALL_ETC_DIR}"
 	@echo "  export LOGGRABBER_CONFIG_PATH"
 	@echo "  LOGGRABBER_TEMP_PATH=${TEMP_DIR}"
 	@echo "  export LOGGRABBER_TEMP_PATH"
+endif
+ifneq ($(shell test -d /etc/ld.so.conf.d && echo -n yes),yes)
+	@echo "  LD_LIBRARY_PATH=\$$LD_LIBRARY_PATH:${INSTALL_LIB_DIR}"
+	@echo "  export LD_LIBRARY_PATH"
+endif
+	@echo
 	@echo
 
 clean:

--- a/install/ldconfig/fw1-loggrabber.conf
+++ b/install/ldconfig/fw1-loggrabber.conf
@@ -1,0 +1,1 @@
+/usr/local/fw1-loggrabber/lib

--- a/install/systemd/fw1-loggrabber.service
+++ b/install/systemd/fw1-loggrabber.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=fw1-loggrabber
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+Environment=LOGGRABBER_CONFIG_PATH=/usr/local/fw1-loggrabber/etc
+WorkingDirectory=/usr/local/fw1-loggrabber
+ExecStart=/usr/local/fw1-loggrabber/bin/fw1-loggrabber
+Restart=always
+RestartSec=5
+TimeoutSec=5min
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This update will do two things:
1) If possible deploy library install path to ldconfig directory (/etc/ld.so.conf.d/) instead of using LD_LIBRARY_PATH.
2) If possible deploy fw1-loggrabber.service file to /etc/systemd/service/.

So long as systemd is the active init system then this service will be installed and loaded, once the configuration files are written the service can simply be started with `systemctl start fw1-loggrabber`.

The service file is configured so that systemd will automatically restart fw1-loggrabber upon any type of failure and configures the current working directory to be /user/local/fw1-loggrabber.

If deploying a systemd service is not possible then the end of `make install` will display the same message as would have otherwise been seen.